### PR TITLE
math.h compilation fixed in C language

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,37 +22,37 @@ languages = [
   {
     name: "C (gcc 7.2.0)",
     source_file: "main.c",
-    compile_cmd: "/usr/local/gcc-7.2.0/bin/gcc main.c",
+    compile_cmd: "/usr/local/gcc-7.2.0/bin/gcc main.c -lm",
     run_cmd: "./a.out"
   },
   {
     name: "C (gcc 6.4.0)",
     source_file: "main.c",
-    compile_cmd: "/usr/local/gcc-6.4.0/bin/gcc main.c",
+    compile_cmd: "/usr/local/gcc-6.4.0/bin/gcc main.c -lm",
     run_cmd: "./a.out"
   },
   {
     name: "C (gcc 6.3.0)",
     source_file: "main.c",
-    compile_cmd: "/usr/local/gcc-6.3.0/bin/gcc main.c",
+    compile_cmd: "/usr/local/gcc-6.3.0/bin/gcc main.c -lm",
     run_cmd: "./a.out"
   },
   {
     name: "C (gcc 5.4.0)",
     source_file: "main.c",
-    compile_cmd: "/usr/local/gcc-5.4.0/bin/gcc main.c",
+    compile_cmd: "/usr/local/gcc-5.4.0/bin/gcc main.c -lm",
     run_cmd: "./a.out"
   },
   {
     name: "C (gcc 4.9.4)",
     source_file: "main.c",
-    compile_cmd: "/usr/local/gcc-4.9.4/bin/gcc main.c",
+    compile_cmd: "/usr/local/gcc-4.9.4/bin/gcc main.c -lm",
     run_cmd: "./a.out"
   },
   {
     name: "C (gcc 4.8.5)",
     source_file: "main.c",
-    compile_cmd: "/usr/local/gcc-4.8.5/bin/gcc main.c",
+    compile_cmd: "/usr/local/gcc-4.8.5/bin/gcc main.c -lm",
     run_cmd: "./a.out"
   },
 


### PR DESCRIPTION
Added `-lm` flag to the commands in db/seeds.rb file to link the math.h file during compilation.
Fixes: #58 