### PR TITLE
Renamed dev-run-*to run-*

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ You need to run Rails API and Worker in order to have Judge0 API fully operation
 
 1. Open new development shell and in there run Rails API server:
     ```
-    $ ./scripts/dev-run-server
+    $ ./scripts/run-server
     ```
 2. Open new development shell again and in there run Worker process:
     ```
-    $ ./scripts/dev-run-worker
+    $ ./scripts/run-workers
     ```
 3. Open http://localhost:3000 in your browser.
 


### PR DESCRIPTION
Files ./scripts/dev-run-* do not exists. So I assume you mean ./scripts/run-* as this works perfectly fine.