### PR TITLE
Fix #123

### DIFF
--- a/app/jobs/isolate_job.rb
+++ b/app/jobs/isolate_job.rb
@@ -212,8 +212,9 @@ class IsolateJob < ApplicationJob
 
   def cleanup(raise_exception = true)
     fix_permissions
-    `sudo rm -rf #{boxdir}/* #{tmpdir}/*`
+    `sudo rm -rf #{workdir}/* #{tmpdir}/*`
     `isolate #{cgroups_flag} -b #{box_id} --cleanup`
+    `sudo rm -rf #{workdir} #{tmpdir}`
     raise "Cleanup of sandbox #{box_id} failed." if raise_exception && Dir.exists?(workdir)
   end
 
@@ -223,7 +224,7 @@ class IsolateJob < ApplicationJob
   end
 
   def fix_permissions
-    `sudo chown -R $(whoami): #{boxdir}`
+    `sudo chown -R $(whoami): #{workdir}`
   end
 
   def get_metadata


### PR DESCRIPTION
Fixes  #123

the command `sudo rm -rf #{boxdir}/* #{tmpdir}/*` clears the `box` directory inside the workdir so isolate throws an error, because the workdir isn't empty. It contains files such as: stdin.txt, stdout.txt, e.t.c